### PR TITLE
Allow 60 days for file upload retention instead of 2 days

### DIFF
--- a/conf/domain.cfg.lua
+++ b/conf/domain.cfg.lua
@@ -69,6 +69,11 @@ Component "xmpp-upload.__DOMAIN__" "http_upload"
   http_upload_file_size_limit = 100 * 1024 * 1024 -- bytes
   http_upload_quota = 10 * 1024 * 1024 * 1024 -- bytes
 
+  -- Time after which uploaded files are deleted
+  -- Don't put too low or a client that was offline for some
+  -- time won't be able to find the files
+  http_file_expire_after = 5184000 -- seconds (60 days)
+
 ---Set up a VJUD service
 Component "vjud.__DOMAIN__" "vjud"
   vjud_disco_name = "__DOMAIN__ User Directory"


### PR DESCRIPTION
2 days was really too low. If i'm offline for 2 days i can't download any of the files i received while offline... 2 months is more reasonable i think?