### PR TITLE
correct DNS record instructions

### DIFF
--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -5,7 +5,7 @@ To be able to effectively use Metronome / your XMPP server, you need:
 ```text
 # Mandatory
 _xmpp-client._tcp 3600 IN SRV 0 5 5222 __DOMAIN__.
-_xmpp-client._tcp 3600 IN SRV 0 5 5269 __DOMAIN__.
+_xmpp-server._tcp 3600 IN SRV 0 5 5269 __DOMAIN__.
 
 # For muc (chatrooms) and file uploads
 muc 3600 IN CNAME __DOMAIN__.

--- a/doc/POST_INSTALL_fr.md
+++ b/doc/POST_INSTALL_fr.md
@@ -5,7 +5,7 @@ Pour pouvoir utiliser Metronome / votre serveur XMPP, il est nécessaire:
 ```text
 # Obligatoires
 _xmpp-client._tcp 3600 IN SRV 0 5 5222 __DOMAIN__.
-_xmpp-client._tcp 3600 IN SRV 0 5 5269 __DOMAIN__.
+_xmpp-server._tcp 3600 IN SRV 0 5 5269 __DOMAIN__.
 
 # Pour le muc (salons) et partage de fichier:
 muc 3600 IN CNAME __DOMAIN__.

--- a/hooks/custom_dns_rules
+++ b/hooks/custom_dns_rules
@@ -13,7 +13,7 @@ cat << EOF >> $YNH_STDRETURN
   type: "SRV"
   value: "0 5 5222 $domain."
 
-- name: "_xmpp-client._tcp$suffix"
+- name: "_xmpp-server._tcp$suffix"
   ttl: 3600
   type: "SRV"
   value: "0 5 5269 $domain."


### PR DESCRIPTION
The suggested DNS records supplied **2** client DNS records but no for the server. As per the [XMPP.org wiki][1], 5269 is the default port for server to server connections.

[1]: https://wiki.xmpp.org/web/SRV_Records

Closes: #12