### PR TITLE
Cleanup DNS hook to be consistent with Post-Install doc

### DIFF
--- a/hooks/custom_dns_rules
+++ b/hooks/custom_dns_rules
@@ -8,22 +8,22 @@ then
 fi
 
 cat << EOF >> $YNH_STDRETURN
-- name: "_xmpp-client._tcp$suffix"
+- name: "_xmpp-client._tcp"
   ttl: 3600
   type: "SRV"
   value: "0 5 5222 $domain."
 
-- name: "_xmpp-server._tcp$suffix"
+- name: "_xmpp-server._tcp"
   ttl: 3600
   type: "SRV"
   value: "0 5 5269 $domain."
 
-- name: "muc$suffix"
+- name: "muc"
   ttl: 3600
   type: "CNAME"
   value: "$domain."
 
-- name: "xmpp-upload$suffix"
+- name: "xmpp-upload"
   ttl: 3600
   type: "CNAME"
   value: "$domain."


### PR DESCRIPTION
## Problem

Today there are inconsistencies between the DNS hook (https://github.com/YunoHost-Apps/metronome_ynh/blob/master/hooks/custom_dns_rules) and the Post-Install documentation (https://github.com/YunoHost-Apps/metronome_ynh/blob/master/doc/POST_INSTALL.md)

- In the hook, the DNS records are using a suffix, example: 
```
- name: "_xmpp-client._tcp$suffix"
  ttl: 3600
  type: "SRV"
  value: "0 5 5222 $domain."
```

- In the documentation, there is no referece to a suffix, example:
```
_xmpp-client._tcp 3600 IN SRV 0 5 5222 __DOMAIN__.
```

## Solution

This PR proposes to remove all references to `$suffix` parameter in the hook to match what is recommended in the Post-Install description.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
